### PR TITLE
Fix package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "webofthings",
   "version": "0.0.1",
   "scripts" : {
-    "start": node demo.js"
+    "start": "node demo.js"
   },
   "dependencies": {
     "ws": "latest"


### PR DESCRIPTION
npm install fails without the missing `"`, throwing the following error:
```
npm ERR! install Couldn't read dependencies
npm ERR! Failed to parse json
npm ERR! Unexpected token o
npm ERR! File: /home/jakehart/dev/web-of-things-framework/package.json
npm ERR! Failed to parse package.json data.
npm ERR! package.json must be actual JSON, not just JavaScript.
npm ERR! 
npm ERR! This is not a bug in npm.
npm ERR! Tell the package author to fix their package.json file. JSON.parse

npm ERR! System Linux 3.19.0-18-generic
npm ERR! command "/usr/bin/node" "/usr/bin/npm" "install"
npm ERR! cwd /home/jakehart/dev/web-of-things-framework
npm ERR! node -v v0.10.37
npm ERR! npm -v 1.4.28
npm ERR! file /home/jakehart/dev/web-of-things-framework/package.json
npm ERR! code EJSONPARSE
npm ERR! 
npm ERR! Additional logging details can be found in:
npm ERR!     /home/jakehart/dev/web-of-things-framework/npm-debug.log
npm ERR! not ok code 0
```