### PR TITLE
Loop closure and type issues

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,63 @@
+###############################################################################
+# Set default behavior to automatically normalize line endings.
+###############################################################################
+* text=auto
+
+###############################################################################
+# Set default behavior for command prompt diff.
+#
+# This is need for earlier builds of msysgit that does not have it on by
+# default for csharp files.
+# Note: This is only used by command line
+###############################################################################
+#*.cs     diff=csharp
+
+###############################################################################
+# Set the merge driver for project and solution files
+#
+# Merging from the command prompt will add diff markers to the files if there
+# are conflicts (Merging from VS is not affected by the settings below, in VS
+# the diff markers are never inserted). Diff markers may cause the following 
+# file extensions to fail to load in VS. An alternative would be to treat
+# these files as binary and thus will always conflict and require user
+# intervention with every merge. To do so, just uncomment the entries below
+###############################################################################
+#*.sln       merge=binary
+#*.csproj    merge=binary
+#*.vbproj    merge=binary
+#*.vcxproj   merge=binary
+#*.vcproj    merge=binary
+#*.dbproj    merge=binary
+#*.fsproj    merge=binary
+#*.lsproj    merge=binary
+#*.wixproj   merge=binary
+#*.modelproj merge=binary
+#*.sqlproj   merge=binary
+#*.wwaproj   merge=binary
+
+###############################################################################
+# behavior for image files
+#
+# image files are treated as binary by default.
+###############################################################################
+#*.jpg   binary
+#*.png   binary
+#*.gif   binary
+
+###############################################################################
+# diff behavior for common document formats
+# 
+# Convert binary document formats to text before diffing them. This feature
+# is only available from the command line. Turn it on by uncommenting the 
+# entries below.
+###############################################################################
+#*.doc   diff=astextplain
+#*.DOC   diff=astextplain
+#*.docx  diff=astextplain
+#*.DOCX  diff=astextplain
+#*.dot   diff=astextplain
+#*.DOT   diff=astextplain
+#*.pdf   diff=astextplain
+#*.PDF   diff=astextplain
+#*.rtf   diff=astextplain
+#*.RTF   diff=astextplain

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ notes
 *.suo
 obj/
 bin/
+.ntvs_analysis.dat

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@ design.txt
 readme
 notes
 
+# Visual Studio Node.js plug-in files
+*.njsproj
+*.suo
+obj/
+bin/

--- a/bindings.md
+++ b/bindings.md
@@ -66,7 +66,7 @@ wot.thing("door12",
     },
     stop: function (thing) {
     },
-    unlock: function () {
+    unlock: function (thing) {
       console.log("unlocking door12");
     }
   });

--- a/demo.js
+++ b/demo.js
@@ -15,7 +15,7 @@ wot.thing("agent12",
       console.log("light is " + (thing.light.on ? "on" : "off"));
     },
     stop: function (thing) {
-    },
+    }
   });
 
 wot.thing("door12",
@@ -39,7 +39,7 @@ wot.thing("door12",
     },
     stop: function (thing) {
     },
-    unlock: function () {
+    unlock: function (thing) {
       console.log("unlocking door12");
     }
   });
@@ -58,7 +58,7 @@ wot.thing("switch12",
       console.log("started switch12");
     },
     stop: function (thing) {
-    },
+    }
   });
 
 // test for resolving circular dependencies
@@ -74,7 +74,7 @@ wot.thing("foo1",
       console.log("foo1's bar is " + thing.bar._name);
     },
     stop: function (thing) {
-    },
+    }
   });
 
 wot.thing("bar1",
@@ -88,7 +88,7 @@ wot.thing("bar1",
       console.log("bar1's foo is " + thing.foo._name);
     },
     stop: function (thing) {
-    },
+    }
   });
 
 wot.register_proxy("http://localhost:8888/wot/switch12", function (thing) {

--- a/framework.js
+++ b/framework.js
@@ -19,469 +19,441 @@ httpd.set_registry(registry);  // pass reference to http server so it can serve 
 wsd.set_registry(registry);
 
 // create new thing given its unique name, model and implementation
-function thing (name, model, implementation)
-{
-  console.log("creating: " + name);
-
-  var options = url.parse(url.resolve(base, name));
-  
-  var thing = new function Thing () {
-    this._name = name;
-    this._uri = options.href;
-    this._model = model;
-    this._observers = {};
-    this._properties = {};
-    this._values = {};
-    this._running = false;
-    this._implementation = implementation;
-    register_thing(model, this);
-
-    init_events (this);
-    init_properties (this);
-    init_actions (this);
-    init_dependencies (this);
-  };
-  
-  // if no dependencies, start the new thing now if not already running
-      
-  if (thing._unresolved == 0 && !thing._running)
-  {
-    console.log("starting1: " + name);
-    implementation.start(thing);
-    thing._running = true;
-  }
+function thing(name, model, implementation) {
+    console.log("creating: " + name);
+    
+    var options = url.parse(url.resolve(base, name));
+    
+    var thing = new function Thing() {
+        this._name = name;
+        this._uri = options.href;
+        this._model = model;
+        this._observers = {};
+        this._properties = {};
+        this._values = {};
+        this._running = false;
+        this._implementation = implementation;
+        register_thing(model, this);
+        
+        init_events(this);
+        init_properties(this);
+        init_actions(this);
+        init_dependencies(this);
+        };
+    
+    // if no dependencies, start the new thing now if not already running
+    
+    if (thing._unresolved === 0 && !thing._running) {
+        console.log("starting1: " + name);
+        implementation.start(thing);
+        thing._running = true;
+    }
 }
 
 // create a proxy for a thing on a remote server
 // will call handler(thing) once thing is ready
 // handler is null if called from init_dependencies
-function register_proxy (uri, succeed, fail)
-{
-  var options = url.parse(url.resolve(base, uri));
-  
-  test_host(options.hostname, 
+function register_proxy(uri, succeed, fail) {
+    var options = url.parse(url.resolve(base, uri));
+    
+    test_host(options.hostname, 
     function () {
-      // local host so use local thing
-      var thing = registry[options.href];
-      
-      if (thing)
-        succeed(thing.thing);
-      else // not yet created
-      {
-        console.log('waiting for ' + uri + ' to be created');
-        record_handler(uri, succeed);
-      }
-    },
-    function () {
-      // remote host so find proxy
-      console.log(options.hostname + " is remote");
-      launch_proxy(options, succeed, fail);
-    },
-    function () {
-      // unknown host name
-      fail("server couldn't determine IP address for " + options.hostname);
-    });
-}
-
-function register_thing(model, thing)
-{
-  console.log('registering ' + thing._uri);
-  registry[thing._uri] = { model: model, thing: thing };
-}
-
-function launch_proxy(options, succeed, fail)
-{
-  // use HTTP to retrieve model
-  console.log('connecting to ' + options.href);
-  
-  return http.get (options, function(response) {
-    var body = '';
-    response.on('data', function(d) {
-      body += d;
-    });
-
-    response.on('end', function() {
-      try {
-        var model = JSON.parse(body);
+        // local host so use local thing
+        var thing = registry[options.href];
         
-        // now get a socket for the remote server
-        // first check if one already exists
-        wsd.connect(options.hostname, function (ws) {
-          create_proxy(options.href, model, ws, succeed);
-        },
-        function (err) {
-          fail(err);
+        if (thing)
+            succeed(thing.thing);
+        else // not yet created
+        {
+            console.log('waiting for ' + uri + ' to be created');
+            record_handler(uri, succeed);
+        }
+    },
+    function () {
+        // remote host so find proxy
+        console.log(options.hostname + " is remote");
+        launch_proxy(options, succeed, fail);
+    },
+    function () {
+        // unknown host name
+        fail("server couldn't determine IP address for " + options.hostname);
+    });
+}
+
+function register_thing(model, thing) {
+    console.log('registering ' + thing._uri);
+    registry[thing._uri] = { model: model, thing: thing };
+}
+
+function launch_proxy(options, succeed, fail) {
+    // use HTTP to retrieve model
+    console.log('connecting to ' + options.href);
+    
+    return http.get(options, function (response) {
+        var body = '';
+        response.on('data', function (d) {
+            body += d;
         });
-      } catch (e) {
-        fail ("couldn't load " + options.href + ", " + e);
-      }
+        
+        response.on('end', function () {
+            try {
+                var model = JSON.parse(body);
+                
+                // now get a socket for the remote server
+                // first check if one already exists
+                wsd.connect(options.hostname, function (ws) {
+                    create_proxy(options.href, model, ws, succeed);
+                },
+        function (err) {
+                    fail(err);
+                });
+            } catch (e) {
+                fail("couldn't load " + options.href + ", " + e);
+            }
+        });
+        
+        response.on('error', function (err) {
+            fail("couldn't load " + options.href + ", error: " + err);
+        });
     });
-  
-    response.on('error', function(err) {
-      fail ("couldn't load " + options.href + ", error: " + err);
-    });
-  });
 }
 
-function unregister_proxy(uri)
-{
-  // *** implement me *** needs to remove proxy from list of proxies for given uri
-  console.log("*** unregister_proxy isn't implemented");
+function unregister_proxy(uri) {
+    // *** implement me *** needs to remove proxy from list of proxies for given uri
+    console.log("*** unregister_proxy isn't implemented");
 }
 
-function create_proxy(uri, model, ws, handler)
-{
-  console.log("register proxy: " + uri);
-  
-  var thing = new function Proxy () {
-    this._uri = uri;
-    this._model = model;
-    this._observers = {};
-    this._properties = {};
-    this._values = {};
-    this._running = false;
-    register_thing(model, this);
- 
-    init_events (this);
-    init_properties (this);
-    init_actions (this);
-    init_dependencies (this);
-  };
+function create_proxy(uri, model, ws, handler) {
+    console.log("register proxy: " + uri);
     
-  // register the new proxy
-  registry[uri] = thing;
-  //wsd.things[uri] = thing;
-  wsd.register_proxy(uri, ws);
-      
-  // now register proxy with the thing it proxies for
+    var thing = new function Proxy() {
+        this._uri = uri;
+        this._model = model;
+        this._observers = {};
+        this._properties = {};
+        this._values = {};
+        this._running = false;
+        register_thing(model, this);
+        
+        init_events(this);
+        init_properties(this);
+        init_actions(this);
+        init_dependencies(this);
+        };
     
-  var message = {
-    proxy: thing._uri
-  };
+    // register the new proxy
+    registry[uri] = thing;
+    //wsd.things[uri] = thing;
+    wsd.register_proxy(uri, ws);
     
-  ws.send(JSON.stringify(message));
-  handler(thing);
-  
-  console.log("registered: " + thing._uri);
+    // now register proxy with the thing it proxies for
+    
+    var message = {
+        proxy: thing._uri
+    };
+    
+    ws.send(JSON.stringify(message));
+    handler(thing);
+    
+    console.log("registered: " + thing._uri);
 }
 
-function notify_dependents (dependee)
-{
-  console.log('notify dependents on ' + dependee._name);
-  var dependents = pending[dependee._name];
-  
-  if (dependents)
-  {
-    var s = "";
-    for (var i = 0; i < dependents.length; ++i)
-    {
-      if (dependents[i].dependent._name)
-        s += dependents[i].dependent._name + ' ';
+function notify_dependents(dependee) {
+    console.log('notify dependents on ' + dependee._name);
+    var dependents = pending[dependee._name];
+    
+    if (dependents) {
+        var s = "";
+        for (var i = 0; i < dependents.length; ++i) {
+            if (dependents[i].dependent._name)
+                s += dependents[i].dependent._name + ' ';
+        }
+        console.log('dependents are: ' + s);
+    } else
+        console.log('no dependents');
+    
+    if (dependents) {
+        for (var i = 0; i < dependents.length; ++i) {
+            var dependency = dependents[i];
+            
+            if (dependency.handler) {
+                dependency.handler(dependee);
+            } else if (dependency.dependent) {
+                var thing = dependency.dependent;
+                var property = dependency.property;
+                resolve_dependency(thing, property, dependee);
+            }
+        }
+        
+        delete pending[dependee._name];
     }
-    console.log('dependents are: ' + s);
-  }
-  else
-    console.log('no dependents');
-  
-  if (dependents)
-  {
-    for (var i = 0; i < dependents.length; ++i)
-    {
-      var dependency = dependents[i];
-      
-      if (dependency.handler) {
-        dependency.handler(dependee);
-      } else if (dependency.dependent) {
-        var thing = dependency.dependent;
-        var property = dependency.property;
-        resolve_dependency(thing, property, dependee)
-      }
-    }
-  
-    delete pending[dependee._name];
-  }
 }
 
 // someone wants to use a handler for a local
 // thing that has yet to be created
-function record_handler(dependee, handler)
-{
-  if (!pending[dependee])
-  	pending[dependee] = [];
-  	
-  pending[dependee].push({handler: handler});
+function record_handler(dependee, handler) {
+    if (!pending[dependee])
+        pending[dependee] = [];
+    
+    pending[dependee].push({ handler: handler });
 }
 
 // dependent is a thing, property is the property name for the dependee
 // and dependee is the *name*  for the thing this thing is depending on
-function record_dependency(dependent, property, dependee)
-{
-  if (!pending[dependee])
-  	pending[dependee] = [];
-  	
-  pending[dependee].push({property: property, dependent: dependent});
+function record_dependency(dependent, property, dependee) {
+    if (!pending[dependee])
+        pending[dependee] = [];
+    
+    pending[dependee].push({ property: property, dependent: dependent });
 }
 
-function resolve_dependency(thing, property, dependee)
-{
-  console.log('setting ' +  thing._name + "'s " + property + " to " + dependee._name);
-  thing[property] = dependee;
-  
-  if (--thing._unresolved <= 0 && thing._implementation)
-  {
-    console.log("starting2: " + thing._name);
-    thing._implementation.start(thing);
-    thing._running = true;
-  }
+function resolve_dependency(thing, property, dependee) {
+    console.log('setting ' + thing._name + "'s " + property + " to " + dependee._name);
+    thing[property] = dependee;
+    
+    if (--thing._unresolved <= 0 && thing._implementation) {
+        console.log("starting2: " + thing._name);
+        thing._implementation.start(thing);
+        thing._running = true;
+    }
 }
 
 // resolve all dependencies for this thing
 // these could be local things on this server
 // otherwise we need to create proxies for them
 // a given dependency must only be given once
-function init_dependencies(thing)
-{
-  var dependencies = thing._model["@dependencies"];
-  var name, count = 0;
-  
-  // first count the number of dependencies
-  for (name in dependencies)
-  {
-    if (dependencies.hasOwnProperty(name))
-      ++count;
-  }
-  
-  thing._unresolved = count;
+function init_dependencies(thing) {
+    var dependencies = thing._model["@dependencies"];
+    var name, count = 0;
+    
+    // first count the number of dependencies
+    for (name in dependencies) {
+        if (dependencies.hasOwnProperty(name))
+            ++count;
+    }
+    
+    thing._unresolved = count;
+    
+    for (name in dependencies) {
+        if (dependencies.hasOwnProperty(name)) {
+            var uri = dependencies[name];
+            console.log("dependee: " + uri);
+            
+            // *** fix me - handle malformed uri ***
+            uri = url.parse(url.resolve(thing._uri, uri)).href;
+            var entry = registry[uri];
+            
+            if (entry)
+                resolve_dependency(thing, name, entry.thing);
+            else {
+                var target = url.resolve(base, uri);
+                record_dependency(thing, name, target);
+                
+                // create proxy if uri is for a remote thing
+                register_proxy(uri, function (dependee) {
+                        // nothing to do here
+                },
+                    function (err) {
+                    console.log(err);
+                });
+            }
+        }
+    }
+    
+    // some things may be waiting for this thing
+    console.log("notifying dependents for " + thing._uri);
+    notify_dependents(thing);
+}
 
-  for (name in dependencies)
-  {
-    if (dependencies.hasOwnProperty(name))
-    {
-      var uri = dependencies[name];
-      console.log("dependee: " + uri);
-
-      // *** fix me - handle malformed uri ***
-      uri = url.parse(url.resolve(thing._uri, uri)).href;
-      var entry = registry[uri];
-
-      if (entry)
-        resolve_dependency(thing, name, entry.thing);
-      else
-      {
-        var target = url.resolve(base, uri)
-        record_dependency(thing, name, target);
+function init_events(thing) {
+    var events = thing._model["@events"];
+    
+    thing._raise_event = function (name, data) {
+        var message = {
+            uri: thing._uri,
+            event: name,
+            data: data
+        }
         
-        // create proxy if uri is for a remote thing
-        register_proxy(uri, function (dependee) {
-            // nothing to do here
-          },
-          function (err) {
-            console.log(err);
-          });
-      }
-    }
-  }
-
-  // some things may be waiting for this thing
-  console.log("notifying dependents for " + thing._uri);
-  notify_dependents(thing);
-}
-
-function init_events(thing)
-{
-  var events = thing._model["@events"];
- 
-  thing._raise_event = function(name, data) {
-    var message = {
-      uri: thing._uri,
-      event: name,
-      data: data
+        wsd.notify(message);
+    };
+    
+    for (var ev in events) {
+        if (events.hasOwnProperty(ev))
+            thing._observers[ev] = [];
     }
     
-    wsd.notify(message);
-  };
-
-  for (var ev in events)
-  {
-    if (events.hasOwnProperty(ev))
-      thing._observers[ev] = [];
-  }
-
-  thing._observe = function (name, handler) {
-    var observers = thing._observers[name];
-      
-    // check handler is a function
-      
-    if (! (handler && getClass.call(handler) == '[object Function]') )
-      throw("event handler is not a function");
-      
-    // if observers is null, an illegal event name
+    thing._observe = function (name, handler) {
+        var observers = thing._observers[name];
+        
+        // check handler is a function
+        
+        if (!(handler && getClass.call(handler) == '[object Function]'))
+            throw ("event handler is not a function");
+        
+        // if observers is null, an illegal event name
+        
+        if (!observers)
+            throw ("undefined event name");
+        
+        // check if this handler is already defined
+        
+        for (var i = 0; i < observers.length; ++i) {
+            if (observers[i] == handler)
+                return;
+        }
+        
+        observers.push(handler);
+    };
     
-    if (!observers)
-      throw("undefined event name");
-      
-    // check if this handler is already defined
-      
-    for (var i = 0; i < observers.length; ++i)
-    {
-      if (observers[i] == handler)
-        return;
-    }
-      
-    observers.push(handler);
-  };
-          
-  thing._unobserve = function (name, handler) {
-    var observers = thing._observers[name];
-      
-    // check handler is a function
-      
-    if (! (handler && getClass.call(handler) == '[object Function]') )
-      throw("event handler is not a function");
-      
-    // if observers is null, an illegal event name
-      
-    if (!observers)
-      throw("undefined event name");
-      
-    // search for this handler
-      
-    for (var i = 0; i < observers.length; ++i)
-    {
-      if (observers[i] == handler)
-      {
-        delete observers[i];
-        return;
-      }
-    }
-  };
+    thing._unobserve = function (name, handler) {
+        var observers = thing._observers[name];
+        
+        // check handler is a function
+        
+        if (!(handler && getClass.call(handler) == '[object Function]'))
+            throw ("event handler is not a function");
+        
+        // if observers is null, an illegal event name
+        
+        if (!observers)
+            throw ("undefined event name");
+        
+        // search for this handler
+        
+        for (var i = 0; i < observers.length; ++i) {
+            if (observers[i] == handler) {
+                delete observers[i];
+                return;
+            }
+        }
+    };
 }
-  
+
 // initialise thing's getters and setters
 // if ws is null, thing isn't a proxy and hence
 // we need to notify property changes to its proxies
-function init_properties (thing, ws)
-{
-  // initialise getters and setters for properties
-  // this doesn't yet validate property values
-  // it also assumes all properties are writable (bad!)
-  
-  var properties = thing._model["@properties"];
-      
-  if (ws)
-  {     
-    for (var prop in properties)
+function init_properties(thing, ws) {
+    // initialise getters and setters for properties
+    // this doesn't yet validate property values
+    // it also assumes all properties are writable (bad!)
+    
+    var properties = thing._model["@properties"];
+    
+    if (ws) {
+        for (var property in properties) {
+            if (properties.hasOwnProperty(property)) {
+                thing._properties[property] = null;
+                
+                (function (prop) {
+                    Object.defineProperty(thing, prop, {
+                        get: function () {
+                            return thing._values[prop];
+                        },
+                        
+                        set: function (value) {
+                            thing._values[prop] = value;
+                            var message = {
+                                uri: thing._uri,
+                                patch: prop,
+                                data: value
+                            };
+                            
+                            ws.send(JSON.stringify(message));
+                        }
+                    });
+                    
+                })(property);
+            }
+        }
+    } else // local thing so notify all of its proxies
     {
-      if (properties.hasOwnProperty(prop))
-      {
-        thing._properties[prop] = null;
-        Object.defineProperty(thing, prop, {
-          get: function () {
-            return thing._values[prop];
-          },
-        
-          set: function (value) {
-            thing._values[prop] = value;
-            var message = {
-              uri: thing._uri,
-              patch: prop,
-              data: value
-            };
-          
-            ws.send(JSON.stringify(message));
-          }
-        });
-      }
-    }
-  }
-  else // local thing so notify all of its proxies
-  {
-    for (var prop in properties)
-    {
-      if (properties.hasOwnProperty(prop))
-      {
-        thing._properties[prop] = null;
-        Object.defineProperty(thing, prop, {
-          get: function () {
-            return thing._values[prop];
-          },
-        
-          set: function (value) {
-            console.log("setting " + thing._name + "." + prop + " = " + value);
-            thing._values[prop] = value;
-            
-            var message = {
-              uri: thing._uri,
-              patch: prop,
-              data: value
-            };
+        for (var property in properties) {
+            if (properties.hasOwnProperty(property)) {
+                thing._properties[property] = null;
+                
+                (function (prop) {
+                    Object.defineProperty(thing, prop, {
+                        get: function () {
+                            return thing._values[prop];
+                        },
+                        
+                        set: function (value) {
+                            console.log("setting " + thing._name + "." + prop + " = " + value);
+                            thing._values[prop] = value;
+                            
+                            var message = {
+                                uri: thing._uri,
+                                patch: prop,
+                                data: value
+                            };
+                            
+                            wsd.notify(message);
+                        }
+                    });
 
-            wsd.notify(message);
-          }
-        });
-      }
+                })(property);
+            }
+        }
     }
-  }
 }
 
 // initialise thing's actions
 // if ws is null, thing is local and we need
 // to bind the actions to the implementation
-function init_actions (thing, ws)
-{
-  // set up methods for invoking actions on proxied thing
-  // this doesn't yet validate the action's data
-  // this doesn't yet support results returned by actions
-  // which would need to be handled asynchronously
-  // most likely via returning a Promise for the result
+function init_actions(thing, ws) {
+    // set up methods for invoking actions on proxied thing
+    // this doesn't yet validate the action's data
+    // this doesn't yet support results returned by actions
+    // which would need to be handled asynchronously
+    // most likely via returning a Promise for the result
     
-  var actions = thing._model["@actions"];
-
-  if (ws) // proxied thing so pass to remote thing
-  {
-    for (var act in actions)
+    var actions = thing._model["@actions"];
+    
+    if (ws) // proxied thing so pass to remote thing
     {
-      if (actions.hasOwnProperty(act))
-      {
-        thing[act] = function (data) {
-          var message = {
-            uri: thing._uri,
-            action: act,
-            data: data
-          };
-          
-          ws.send(JSON.stringify(message));
-        };
-      }
-    }
-  }
-  else // local thing so invoke implementation
-  {
-    for (var act in actions)
-    {
-      if (actions.hasOwnProperty(act))
-      {
-        thing[act] = function (data) {
-          thing._implementation[act](thing, data);
+        for (var action in actions) {
+            if (actions.hasOwnProperty(action)) {
+                (function (act) {
+                    thing[act] = function (data) {
+                        var message = {
+                            uri: thing._uri,
+                            action: act,
+                            data: data
+                        };
+                        
+                        ws.send(JSON.stringify(message));
+                    };
+                })(action);
+            }
         }
-      }
+    } else // local thing so invoke implementation
+    {
+        for (var action in actions) {
+            if (actions.hasOwnProperty(action)) {
+                (function (act) {
+                    thing[act] = function (data) {
+                        thing._implementation[act](thing, data);
+                    }
+
+                })(action);
+            }
+        }
     }
-  }
 }
 
-function test_host(host, local, remote, unknown)
-{
-  dns.resolve(host, function (err, addresses) {
-    if (err) {      
-      if (unknown)
-        unknown();
-    } else {
-      if (is_local(addresses))
-        local();
-      else
-        remote();
-    }
-  });
+function test_host(host, local, remote, unknown) {
+    dns.resolve(host, function (err, addresses) {
+        if (err) {
+            if (unknown)
+                unknown();
+        } else {
+            if (is_local(addresses))
+                local();
+            else
+                remote();
+        }
+    });
 }
 
 // initialise list of local IP addresses
@@ -490,25 +462,24 @@ function test_host(host, local, remote, unknown)
 
 var ifaces = os.networkInterfaces();
 var localAddresses = [];
-  
-Object.keys(ifaces).forEach( function (ifname) {
-  ifaces[ifname].forEach(function (iface) {
-    localAddresses.push(iface.address);
-  });
+
+Object.keys(ifaces).forEach(function (ifname) {
+    ifaces[ifname].forEach(function (iface) {
+        localAddresses.push(iface.address);
+    });
 });
 
-function is_local(addresses)
-{
-  for (var i = 0; i < addresses.length; ++i) {
-    var raddr = addresses[i];
-    
-    for (var j = 0; j < localAddresses.length; ++j) {
-      if (localAddresses[j] === raddr)
-        return true;
+function is_local(addresses) {
+    for (var i = 0; i < addresses.length; ++i) {
+        var raddr = addresses[i];
+        
+        for (var j = 0; j < localAddresses.length; ++j) {
+            if (localAddresses[j] === raddr)
+                return true;
+        }
     }
-  }
-  
-  return false;
+    
+    return false;
 }
 
 exports.thing = thing;

--- a/wsd.js
+++ b/wsd.js
@@ -37,7 +37,7 @@ function find_thing(uri)
   var uri = url.resolve(base, uri);
 
   if (!things.hasOwnProperty(uri)) {
-    return null
+      return null;
   }
   return things[uri].thing;
 }
@@ -48,7 +48,7 @@ function connect (host, succeed, fail)
   
   if (ws)
   {
-    succeeed(ws);  // reuse existing connection
+    succeed(ws);  // reuse existing connection
   }
   else // create new connection
   {
@@ -159,7 +159,7 @@ wss.on('connection', function(ws)
           props[prop] = thing._values[prop];
       }
       
-      prop["_running"] = thing._running;
+      props["_running"] = thing._running;
       
       var response = {
         uri: message.proxy,

--- a/www/wot.js
+++ b/www/wot.js
@@ -1,280 +1,256 @@
 var wot = {
-  things: {},
-  
-  start: function ()
-  {
-     // same origin policy restricts this library to connecting to
-     // HTTP and WebSockets servers with same origin as web page.
-     // does XHR resolve relative URLs with respect to page origin?
-
-    // initialise web socket connection for thing messages
-    // use single connection for all things on the server
+    things: {},
     
-    var host = window.document.location.host.replace(/:.*/, '');
-    this.ws = new WebSocket('ws://' + host + ':8080/webofthings');
-    console.log("websocket connection opening ...");
-     
-    this.ws.onopen = function ()
-    {
-      console.log("websocket connection opened");
-      
-      wot.get("/wot/door12", function(door) {
-        console.log("door is ready");
-        door.unlock();
-      });
-      
-      wot.get("/wot/switch12", function(light) {
-        console.log("light is ready");
-        light.on = true;
-      });
-    };
-
-    this.ws.onclose = function ()
-    {
-      console.log("websocket connection closed");
-    };
-
-    this.ws.onerror = function ()
-    {
-      console.log("websocket connection error");
-    };
-
-    this.ws.onmessage = function (message)
-    {
-      console.log("received message: " + message.data);
-      try {
-        var message = JSON.parse(message.data);
-        wot.dispatch_message(message);
-      } catch (e) {
-        console.log("JSON syntax error in " + message.data);
-      }
-    };
-  },
-    
-  // dispatch message from web socket connection
-  dispatch_message: function (message)
-  {
-    var thing = this.things[message.uri];
-    
-    if (!thing)
-    {
-      console.log("unknown thing: " + message.uri);
-      raise("unknown thing: " + message.uri);
-    }
-    
-    if (message.event)  // notify event to proxy
-    {
-      var observers = thing._observers[message.event];
-      
-      for (var i = 0; i < observers.length; ++i)
-        observers[i](message.name, message.data);
-    }
-    else if (message.state)  // update all properties on proxy 
-    {
-      var obj = message.state;
-      
-      for (var property in obj)
-      {
-        if (obj.hasOwnProperty(property))
-        {
-          thing._values[property] = obj[property];
-        }
-      }
-    }
-    else if (message.patch) // update named property on proxy
-    {
-      thing[message.patch] = message.data;
-    }
-    else
-      console.log("unknown message type: " + JSON.stringify(message));
-  },
-  
-  // creates proxy for thing from JSON-LD model
-  setup_thing: function (uri, json, handler)
-  {
-    var thing = new function ()
-    {
-      wot.init_proxy(this, uri, JSON.parse(json));
-    };
-    
-    handler(thing);
-  },
-  
-  // initialise thing with its uri and parsed JSON-LD model
-  init_proxy: function (thing, uri, model)
-  {
-    var events = model["@events"];
-    var properties = model["@properties"];
-    var actions = model["@actions"];
-    
-    thing._uri = uri;
-    thing._model = model;
-    thing._observers = {};
-    thing._properties = {};
-    thing._values = {};
-    
-    for (var ev in events)
-    {
-      if (events.hasOwnProperty(ev))
-        thing._observers[ev] = [];
-    }
-
-    thing._observe = function (name, handler)
-    { 
-      var observers = thing._observers[name];
-      
-      // check handler is a function
-      
-      if (! (handler && getClass.call(handler) == '[object Function]') )
-        throw("event handler is not a function");
-      
-      // if observers is null, an illegal event name
-      
-      if (!observers)
-        throw("undefined event name");
-      
-      // check if this handler is already defined
-      
-      for (var i = 0; i < observers.length; ++i)
-      {
-        if (observers[i] == handler)
-          return;
-      }
-      
-      observers.push(handler);
-    };
-          
-    thing._unobserve = function (name, handler)
-    {
-      var observers = thing._observers[name];
-      
-      // check handler is a function
-      
-      if (! (handler && getClass.call(handler) == '[object Function]') )
-        throw("event handler is not a function");
-      
-      // if observers is null, an illegal event name
-      
-      if (!observers)
-        throw("undefined event name");
-      
-      // search for this handler
-      
-      for (var i = 0; i < observers.length; ++i)
-      {
-        if (observers[i] == handler)
-        {
-          delete observers[i];
-          return;
-        }
-      }
-    };
-          
-    // initialise getters and setters for properties
-    // this doesn't yet validate property values
-    // it also assumes all properties are writable (bad!)
-    // *** fix me to honor writable meta-property ***
-    for (var prop in properties)
-    {
-      if (properties.hasOwnProperty(prop))
-      {
-        thing._properties[prop] = null;
-        Object.defineProperty(thing, prop, {
-          get: function () {
-            return thing._values[prop];
-          },
-          set: function (value) {
-            // should throw error if property isn't writeable
-            console.log("setting " + prop + " = " + value);
-            thing._values[prop] = value;
-            var message = {
-              uri: thing._uri,
-              patch: prop,
-              data: value
-            };
-
-            wot.ws.send(JSON.stringify(message));
-          }
-        });
-      }
-    }
-
-    // set up methods for invoking actions on proxied thing
-    // this doesn't yet validate the action's data
-    // this doesn't yet support results returned by actions
-    // which would need to be handled asynchronously
-    // most likely via returning a Promise for the result
-    
-    for (var act in actions)
-    {
-      if (actions.hasOwnProperty(act))
-      {
-        thing[act] = function (data) {
-          // invoke action on proxied thing
-          var message = {};
-          message.uri = thing._uri;
-          message.action = act;
-          message.data = data;
-          wot.ws.send(JSON.stringify(message));
+    start: function () {
+        // same origin policy restricts this library to connecting to
+        // HTTP and WebSockets servers with same origin as web page.
+        // does XHR resolve relative URLs with respect to page origin?
+        
+        // initialise web socket connection for thing messages
+        // use single connection for all things on the server
+        
+        var host = window.document.location.host.replace(/:.*/, '');
+        this.ws = new WebSocket('ws://' + host + ':8080/webofthings');
+        console.log("websocket connection opening ...");
+        
+        this.ws.onopen = function () {
+            console.log("websocket connection opened");
+            
+            wot.get("/wot/door12", function (door) {
+                console.log("door is ready");
+                door.unlock();
+            });
+            
+            wot.get("/wot/switch12", function (light) {
+                console.log("light is ready");
+                light.on = true;
+            });
         };
-      }
-    }
+        
+        this.ws.onclose = function () {
+            console.log("websocket connection closed");
+        };
+        
+        this.ws.onerror = function () {
+            console.log("websocket connection error");
+        };
+        
+        this.ws.onmessage = function (message) {
+            console.log("received message: " + message.data);
+            try {
+                var message = JSON.parse(message.data);
+                wot.dispatch_message(message);
+            } catch (e) {
+                console.log("JSON syntax error in " + message.data);
+            }
+        };
+    },
     
-    // now register proxy with thing's server
-    
-    var message = {
-      proxy: uri
-    };
-    
-    wot.ws.send(JSON.stringify(message));
-    this.things[uri] = thing;
-    console.log("registered: " + uri);
-  },
-  
-  list: function (obj)
-  {
-    var s = "";
-    
-    for (var property in obj)
-    {
-      if (obj.hasOwnProperty(property))
-      {
-        s += "\n" + property + ": " + obj[property];
-      }
-    }
-    alert(s);
-  },
-  
-  get: function (path, handler)
-  {
-    var req = new XMLHttpRequest();
-    req.open("GET", path, true);
-    req.setRequestHeader("Pragma", "no-cache");
-    req.setRequestHeader("Cache-Control", "no-cache");
-    req.setRequestHeader("Content-Type", "text/plain");
-    req.onreadystatechange = function (evt)
-    {
-      if (req.readyState == 4)
-      {
-        if (req.status == 200)
+    // dispatch message from web socket connection
+    dispatch_message: function (message) {
+        var thing = this.things[message.uri];
+        
+        if (!thing) {
+            console.log("unknown thing: " + message.uri);
+            raise("unknown thing: " + message.uri);
+        }
+        
+        if (message.event)  // notify event to proxy
         {
-          console.log(req.status +  " Okay, " +req.responseText);
-          
-          handler(new function () {
-            wot.init_proxy(this, path, JSON.parse(req.responseText));
-          });
+            var observers = thing._observers[message.event];
+            
+            for (var i = 0; i < observers.length; ++i)
+                observers[i](message.name, message.data);
+        }
+        else if (message.state)  // update all properties on proxy
+        {
+            var obj = message.state;
+            
+            for (var property in obj) {
+                if (obj.hasOwnProperty(property)) {
+                    thing._values[property] = obj[property];
+                }
+            }
+        }
+        else if (message.patch) // update named property on proxy
+        {
+            thing[message.patch] = message.data;
         }
         else
-        {
-          console.log(req.status +  " Error, " + req.responseText);
+            console.log("unknown message type: " + JSON.stringify(message));
+    },
+    
+    // creates proxy for thing from JSON-LD model
+    setup_thing: function (uri, json, handler) {
+        var thing = new function () {
+            wot.init_proxy(this, uri, JSON.parse(json));
+                };
+        
+        handler(thing);
+    },
+    
+    // initialise thing with its uri and parsed JSON-LD model
+    init_proxy: function (thing, uri, model) {
+        var events = model["@events"];
+        var properties = model["@properties"];
+        var actions = model["@actions"];
+        
+        thing._uri = uri;
+        thing._model = model;
+        thing._observers = {};
+        thing._properties = {};
+        thing._values = {};
+        
+        for (var ev in events) {
+            if (events.hasOwnProperty(ev))
+                thing._observers[ev] = [];
         }
-      }
-    };
+        
+        thing._observe = function (name, handler) {
+            var observers = thing._observers[name];
+            
+            // check handler is a function
+            
+            if (!(handler && getClass.call(handler) == '[object Function]'))
+                throw ("event handler is not a function");
+            
+            // if observers is null, an illegal event name
+            
+            if (!observers)
+                throw ("undefined event name");
+            
+            // check if this handler is already defined
+            
+            for (var i = 0; i < observers.length; ++i) {
+                if (observers[i] == handler)
+                    return;
+            }
+            
+            observers.push(handler);
+        };
+        
+        thing._unobserve = function (name, handler) {
+            var observers = thing._observers[name];
+            
+            // check handler is a function
+            
+            if (!(handler && getClass.call(handler) == '[object Function]'))
+                throw ("event handler is not a function");
+            
+            // if observers is null, an illegal event name
+            
+            if (!observers)
+                throw ("undefined event name");
+            
+            // search for this handler
+            
+            for (var i = 0; i < observers.length; ++i) {
+                if (observers[i] == handler) {
+                    delete observers[i];
+                    return;
+                }
+            }
+        };
+        
+        // initialise getters and setters for properties
+        // this doesn't yet validate property values
+        // it also assumes all properties are writable (bad!)
+        // *** fix me to honor writable meta-property ***
+        for (var prop in properties) {
+            if (properties.hasOwnProperty(prop)) {
+                thing._properties[prop] = null;
 
-    req.send();
-  },
+                (function(prop) {
+                    Object.defineProperty(thing, prop, {
+                        get: function () {
+                            return thing._values[prop];
+                        },
+                        set: function (value) {
+                            // should throw error if property isn't writeable
+                            console.log("setting " + prop + " = " + value);
+                            thing._values[prop] = value;
+                            var message = {
+                                uri: thing._uri,
+                                patch: prop,
+                                data: value
+                            };
+                            
+                            wot.ws.send(JSON.stringify(message));
+                        }
+                    });
+                    
+                })(prop);
+            }
+        }
+        
+        // set up methods for invoking actions on proxied thing
+        // this doesn't yet validate the action's data
+        // this doesn't yet support results returned by actions
+        // which would need to be handled asynchronously
+        // most likely via returning a Promise for the result
+        
+        for (var act in actions) {
+            if (actions.hasOwnProperty(act)) {
+                (function(act) {
+                    thing[act] = function(data) {
+                        // invoke action on proxied thing
+                        var message = {};
+                        message.uri = thing._uri;
+                        message.action = act;
+                        message.data = data;
+                        wot.ws.send(JSON.stringify(message));
+                    };
+                })(act);
+            }
+        }
+        
+        // now register proxy with thing's server
+        
+        var message = {
+            proxy: uri
+        };
+        
+        wot.ws.send(JSON.stringify(message));
+        this.things[uri] = thing;
+        console.log("registered: " + uri);
+    },
+    
+    list: function (obj) {
+        var s = "";
+        
+        for (var property in obj) {
+            if (obj.hasOwnProperty(property)) {
+                s += "\n" + property + ": " + obj[property];
+            }
+        }
+        alert(s);
+    },
+    
+    get: function (path, handler) {
+        var req = new XMLHttpRequest();
+        req.open("GET", path, true);
+        req.setRequestHeader("Pragma", "no-cache");
+        req.setRequestHeader("Cache-Control", "no-cache");
+        req.setRequestHeader("Content-Type", "text/plain");
+        req.onreadystatechange = function (evt) {
+            if (req.readyState === 4) {
+                if (req.status === 200) {
+                    console.log(req.status + " Okay, " + req.responseText);
+                    
+                    handler(new function () {
+                        wot.init_proxy(this, path, JSON.parse(req.responseText));
+                                        });
+                }
+                else {
+                    console.log(req.status + " Error, " + req.responseText);
+                }
+            }
+        };
+        
+        req.send();
+    }
 
   
 };
 
-window.addEventListener("load", function () {wot.start(); }, false);
+window.addEventListener("load", function () { wot.start(); }, false);


### PR DESCRIPTION
The changes here come down a few areas:

1. Loop closures problems - I fixed these by using the (function(prop){})(prop); solution.  Other alternatives (bind, etc) could have been used.

2. Typos - specifically a case where a variable named "prop" should have been "props" and "succeeed" should have been "succeed"

3. Adding the "thing" parameter to the unlock callback in both the demo and the markdown.

It looks like a lot of whitespace changes too - probably from using Visual Studio as my editor.  If you have a preferred format you can let me know what it is and I'll modify my templates and can resubmit a new change that doesn't affect as much whitespace. 