### PR TITLE
Added logs directory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,5 @@ obj/
 *.njsproj
 *.suo
 *.sln
-logs/
+logs/*.log
 

--- a/logs/readme.md
+++ b/logs/readme.md
@@ -1,0 +1,1 @@
+﻿The "logs" directory must exist in the directory tree to write log to the log file.


### PR DESCRIPTION
The logger module creates an error when the logs directory does not
exists. To fix this error  logs directory has been added to the
directory tree with a readme file.