### PR TITLE
Add a write stream logger with winston

### DIFF
--- a/examples/http_express_demo/demo.js
+++ b/examples/http_express_demo/demo.js
@@ -247,13 +247,7 @@ api.use(bodyParser.json());
 api.use(bodyParser.urlencoded({ extended: false }));
 
 // setup the logger
-// use the Winston write stream for Morgan
-var logStream = {
-    write: function(message, encoding){
-        logger.info(message);
-    }
-};
-api.use(morgan('combined', {stream: logStream}))
+api.use(morgan('combined', {stream: logger.stream}))
 
 // keep reference to config
 api.config = global.appconfig;

--- a/logger.js
+++ b/logger.js
@@ -148,6 +148,14 @@ function log_debug(msg, val1, val2, val3, val4) {
     }
 }
 
+// write stream object
+var log_stream = {
+    write: function(message, encoding){
+        log_info(message);
+    }
+};
+
 exports.error = log_error;
 exports.info = log_info;
 exports.debug = log_debug;
+exports.stream = log_stream;


### PR DESCRIPTION
Add Morgan as the stream logger which can be used combined with winston. We can use morgan in to log express transformations, while use of winston to log other logs.