### PR TITLE
Add `start:coap_demo` and `start:http_demo` in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,10 @@
   "name": "webofthings",
   "version": "0.0.1",
   "scripts": {
-    "start": "node demo.js",
-    "test": "./node_modules/.bin/mocha"
+    "start": "npm run start:coap_demo & npm run start:http_demo",
+    "start:coap_demo": "node ./examples/coap_demo/demo.js",
+    "start:http_demo": "node ./examples/http_demo/demo.js",
+    "test": "mocha"
   },
   "dependencies": {
     "async": "^1.5.0",


### PR DESCRIPTION
Hello :)

I added `start:coap_demo` and `start:http_demo` command.

Test is failing. Is this ok?

```
> webofthings@0.0.1 test /Users/hoge/Programming/w3c/web-of-things-framework
> mocha



  Thing with multiple properties should initialize correctly
    setting values
      1) should have properly set values


  0 passing (10ms)
  1 failing

  1) Thing with multiple properties should initialize correctly setting values should have properly set values:
     TypeError: wot.thing is not a function
      at Context.<anonymous> (test/closure-loop-repro.js:8:17)



npm ERR! Test failed.  See above for more details.
```

Cheers.